### PR TITLE
update srt iOS build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,18 @@ ffplay -analyzeduration 100 -i 'srt://${YOUR_IP_ADDRESS}?mode=listener'
 ```
 
 ### :memo: How can I run example project?
-SRTHaishinKit needs other dependicies. Please build.
+SRTHaishinKit needs other dependencies. Please build.
 
 #### iOS
+
 ```sh
 carthage update --platform iOS
-cd /Vendor/SRT/
-./build-openssl-iOS.sh
-./build-srt-iOS.sh
 ```
+~~cd /Vendor/SRT/
+./build-openssl-iOS.sh
+./build-srt-iOS.sh~~
+
+
 
 #### macOS
 ```sh
@@ -111,10 +114,10 @@ brew install srt
 Yes. Consulting fee is [$50](https://www.paypal.me/shogo4405/50USD)/1 incident. I don't recommend. 
 Please consider to use Issues.
 
-## Dependicies
+## Dependencies
 1. https://github.com/Haivision/srt
 1. https://github.com/shogo4405/HaishinKit.swift
 1. https://github.com/shogo4405/Logboard
 
-## Refernces
+## References
 * https://www.haivision.com/products/srt-secure-reliable-transport/

--- a/SRTHaishinKit.xcodeproj/project.pbxproj
+++ b/SRTHaishinKit.xcodeproj/project.pbxproj
@@ -568,6 +568,7 @@
 			buildConfigurationList = 2923D2DE21734075000A5E9B /* Build configuration list for PBXNativeTarget "SRTHaishinKit iOS" */;
 			buildPhases = (
 				2923D2D421734075000A5E9B /* Headers */,
+				4B3363C5230B31ED00A67762 /* Build openssl And SRT */,
 				2923D2D521734075000A5E9B /* Sources */,
 				2923D2D621734075000A5E9B /* Frameworks */,
 				2923D2D721734075000A5E9B /* Resources */,
@@ -704,6 +705,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks\n\n";
+		};
+		4B3363C5230B31ED00A67762 /* Build openssl And SRT */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build openssl And SRT";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# build openssl and srt for ios\npushd ${PROJECT_DIR}/Vendor/SRT\nif [ -e libsrt-iOS.a ]\nthen\n    exit 0\nfi\n\n./build-openssl-iOS.sh\n./build-srt-iOS.sh\npopd\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1134,7 +1153,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = SUEQ2SZ2L5;
+				DEVELOPMENT_TEAM = 8E3XAWXZU9;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1158,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = SUEQ2SZ2L5;
+				DEVELOPMENT_TEAM = 8E3XAWXZU9;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/Vendor/SRT/build-openssl-iOS.sh
+++ b/Vendor/SRT/build-openssl-iOS.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SDKVERSION=$(xcrun --sdk iphoneos --show-sdk-version)
+
 if which $(pwd)/OpenSSL-for-iPhone >/dev/null; then
   echo ""
 else
@@ -7,5 +9,5 @@ else
 fi
 
 pushd OpenSSL-for-iPhone
-./build-libssl.sh
+./build-libssl.sh --archs="x86_64 i386 arm64 armv7s armv7"
 popd

--- a/Vendor/SRT/build-srt-iOS.sh
+++ b/Vendor/SRT/build-srt-iOS.sh
@@ -7,7 +7,7 @@ else
 fi
 
 export IPHONEOS_DEPLOYMENT_TARGET=8.0
-SDKVERSION=12.1
+SDKVERSION=$(xcrun --sdk iphoneos --show-sdk-version)
 
 srt() {
   IOS_OPENSSL=$(pwd)/OpenSSL-for-iPhone/bin/$1${SDKVERSION}-$3.sdk
@@ -15,6 +15,8 @@ srt() {
   mkdir -p ./build/iOS/$3
   pushd ./build/iOS/$3
   ../../../srt/configure --cmake-prefix-path=$IOS_OPENSSL --ios-platform=$2 --ios-arch=$3 --cmake-toolchain-file=scripts/iOS.cmake
+  make
+  install_name_tool -id "@executable_path/Frameworks/libsrt.1.3.3.dylib" libsrt.1.3.3.dylib
   popd
 }
 


### PR DESCRIPTION
Updated the external dependencies scripts and add openssl and srt build triggers to the iOS Framework build.

These changes allow for installation with Carthage without manual installation steps.

* get latest iOS sdk version from xcrun
* run make after ./configure
* limit openssl archs to x86_64 i386 arm64 armv7s armv7
* run build scripts from script phase
* only run build script when libsrt-iOS.a is not present
* tweak README
